### PR TITLE
[language server] Async symbolication on file saves (#163)

### DIFF
--- a/language/move-analyzer/src/bin/move-analyzer.rs
+++ b/language/move-analyzer/src/bin/move-analyzer.rs
@@ -9,6 +9,7 @@ use lsp_types::{
     TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
     WorkDoneProgressOptions,
 };
+use std::sync::{Arc, Mutex};
 
 use move_analyzer::{
     completion::on_completion_request,
@@ -42,6 +43,7 @@ fn main() {
     let mut context = Context {
         connection,
         files: VirtualFileSystem::default(),
+        symbols: Arc::new(Mutex::new(symbols::Symbolicator::empty_symbols())),
     };
     let capabilities = serde_json::to_value(lsp_types::ServerCapabilities {
         // The server receives notifications from the client as users open, close,
@@ -97,24 +99,18 @@ fn main() {
     let initialize_params: lsp_types::InitializeParams =
         serde_json::from_value(client_response).expect("could not deserialize client capabilities");
 
-    let symbols = if symbols::DEFS_AND_REFS_SUPPORT {
-        eprintln!("symbolication started");
-
-        match initialize_params.root_uri {
-            Some(uri) => match symbols::Symbolicator::get_symbols(&uri.to_file_path().unwrap()) {
-                Ok(v) => v,
-                Err(_) => symbols::Symbolicator::empty_symbols(),
-            },
-            None => symbols::Symbolicator::empty_symbols(),
+    let mut symbolicator_runner = symbols::SymbolicatorRunner::idle();
+    if symbols::DEFS_AND_REFS_SUPPORT {
+        if let Some(uri) = initialize_params.root_uri {
+            symbolicator_runner = symbols::SymbolicatorRunner::new(&uri, context.symbols.clone());
+            symbolicator_runner.run();
         }
-    } else {
-        symbols::Symbolicator::empty_symbols()
     };
 
     loop {
         match context.connection.receiver.recv() {
             Ok(message) => match message {
-                Message::Request(request) => on_request(&context, &request, &symbols),
+                Message::Request(request) => on_request(&context, &request),
                 Message::Response(response) => on_response(&context, &response),
                 Message::Notification(notification) => {
                     match notification.method.as_str() {
@@ -124,7 +120,7 @@ fn main() {
                             // It ought to, especially once it begins processing requests that may
                             // take a long time to respond to.
                         }
-                        _ => on_notification(&mut context, &notification),
+                        _ => on_notification(&mut context, &symbolicator_runner, &notification),
                     }
                 }
             },
@@ -136,17 +132,18 @@ fn main() {
     }
 
     io_threads.join().expect("I/O threads could not finish");
+    symbolicator_runner.quit();
     eprintln!("Shut down language server '{}'.", exe);
 }
 
-fn on_request(context: &Context, request: &Request, symbols: &symbols::Symbols) {
+fn on_request(context: &Context, request: &Request) {
     match request.method.as_str() {
         lsp_types::request::Completion::METHOD => on_completion_request(context, request),
         lsp_types::request::GotoDefinition::METHOD => {
-            symbols::on_go_to_def_request(context, request, symbols)
+            symbols::on_go_to_def_request(context, request, &context.symbols.lock().unwrap())
         }
         lsp_types::request::References::METHOD => {
-            symbols::on_references_request(context, request, symbols)
+            symbols::on_references_request(context, request, &context.symbols.lock().unwrap())
         }
         _ => todo!("handle request '{}' from client", request.method),
     }
@@ -156,13 +153,21 @@ fn on_response(_context: &Context, _response: &Response) {
     todo!("handle response from client");
 }
 
-fn on_notification(context: &mut Context, notification: &Notification) {
+fn on_notification(
+    context: &mut Context,
+    symbolicator_runner: &symbols::SymbolicatorRunner,
+    notification: &Notification,
+) {
     match notification.method.as_str() {
         lsp_types::notification::DidOpenTextDocument::METHOD
         | lsp_types::notification::DidChangeTextDocument::METHOD
         | lsp_types::notification::DidSaveTextDocument::METHOD
         | lsp_types::notification::DidCloseTextDocument::METHOD => {
-            on_text_document_sync_notification(&mut context.files, notification)
+            on_text_document_sync_notification(
+                &mut context.files,
+                symbolicator_runner,
+                notification,
+            )
         }
         _ => todo!("handle notification '{}' from client", notification.method),
     }

--- a/language/move-analyzer/src/context.rs
+++ b/language/move-analyzer/src/context.rs
@@ -2,8 +2,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::vfs::VirtualFileSystem;
+use crate::{symbols::Symbols, vfs::VirtualFileSystem};
 use lsp_server::Connection;
+use std::sync::{Arc, Mutex};
 
 /// The context within which the language server is running.
 pub struct Context {
@@ -11,4 +12,6 @@ pub struct Context {
     pub connection: Connection,
     /// The files that the language server is providing information about.
     pub files: VirtualFileSystem,
+    /// Symbolication information
+    pub symbols: Arc<Mutex<Symbols>>,
 }

--- a/language/move-analyzer/src/vfs.rs
+++ b/language/move-analyzer/src/vfs.rs
@@ -16,6 +16,8 @@ use lsp_types::{
     DidOpenTextDocumentParams, DidSaveTextDocumentParams,
 };
 
+use crate::symbols;
+
 /// A mapping from identifiers (file names, potentially, but not necessarily) to their contents.
 #[derive(Debug, Default)]
 pub struct VirtualFileSystem {
@@ -49,6 +51,7 @@ impl VirtualFileSystem {
 /// Updates the given virtual file system based on the text document sync notification that was sent.
 pub fn on_text_document_sync_notification(
     files: &mut VirtualFileSystem,
+    symbolicator_runner: &symbols::SymbolicatorRunner,
     notification: &Notification,
 ) {
     match notification.method.as_str() {
@@ -78,6 +81,7 @@ pub fn on_text_document_sync_notification(
                 parameters.text_document.uri.path(),
                 &parameters.text.unwrap(),
             );
+            symbolicator_runner.run();
         }
         lsp_types::notification::DidCloseTextDocument::METHOD => {
             let parameters =


### PR DESCRIPTION
* Added async symbolication on file saves

* Avoid killing the whole process on compilation failure

* Removed redundant argument

* Addressed review feedback

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
