### PR TITLE
Fix Prover for Starcoin

### DIFF
--- a/language/move-compiler/src/naming/fake_natives.rs
+++ b/language/move-compiler/src/naming/fake_natives.rs
@@ -97,14 +97,14 @@ pub fn resolve_builtin(
         }
     };
     Some(match (module.value().as_str(), function.value().as_str()) {
-        ("vector", "empty") => |tys| IR::Bytecode_::VecPack(expect_one_ty_arg(tys), 0),
-        ("vector", "length") => |tys| IR::Bytecode_::VecLen(expect_one_ty_arg(tys)),
-        ("vector", "borrow") => |tys| IR::Bytecode_::VecImmBorrow(expect_one_ty_arg(tys)),
-        ("vector", "push_back") => |tys| IR::Bytecode_::VecPushBack(expect_one_ty_arg(tys)),
-        ("vector", "borrow_mut") => |tys| IR::Bytecode_::VecMutBorrow(expect_one_ty_arg(tys)),
-        ("vector", "pop_back") => |tys| IR::Bytecode_::VecPopBack(expect_one_ty_arg(tys)),
-        ("vector", "destroy_empty") => |tys| IR::Bytecode_::VecUnpack(expect_one_ty_arg(tys), 0),
-        ("vector", "swap") => |tys| IR::Bytecode_::VecSwap(expect_one_ty_arg(tys)),
+        ("Vector", "empty") => |tys| IR::Bytecode_::VecPack(expect_one_ty_arg(tys), 0),
+        ("Vector", "length") => |tys| IR::Bytecode_::VecLen(expect_one_ty_arg(tys)),
+        ("Vector", "borrow") => |tys| IR::Bytecode_::VecImmBorrow(expect_one_ty_arg(tys)),
+        ("Vector", "push_back") => |tys| IR::Bytecode_::VecPushBack(expect_one_ty_arg(tys)),
+        ("Vector", "borrow_mut") => |tys| IR::Bytecode_::VecMutBorrow(expect_one_ty_arg(tys)),
+        ("Vector", "pop_back") => |tys| IR::Bytecode_::VecPopBack(expect_one_ty_arg(tys)),
+        ("Vector", "destroy_empty") => |tys| IR::Bytecode_::VecUnpack(expect_one_ty_arg(tys), 0),
+        ("Vector", "swap") => |tys| IR::Bytecode_::VecSwap(expect_one_ty_arg(tys)),
         _ => return None,
     })
 }

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -1054,7 +1054,7 @@ impl GlobalEnv {
             let struct_env = module_env.get_struct(*sid);
             let module_name = module_env.get_name();
             module_name.addr() == &BigUint::one()
-                && &*self.symbol_pool.string(module_name.name()) == "event"
+                && &*self.symbol_pool.string(module_name.name()) == "Event"
                 && &*self.symbol_pool.string(struct_env.get_name()) == "EventHandle"
         } else {
             false

--- a/language/move-model/src/well_known.rs
+++ b/language/move-model/src/well_known.rs
@@ -7,8 +7,8 @@
 //! This currently only contains those declarations used somewhere, not all well-known
 //! declarations. It can be extended on the go.
 
-pub const VECTOR_BORROW_MUT: &str = "vector::borrow_mut";
-pub const EVENT_EMIT_EVENT: &str = "event::emit_event";
+pub const VECTOR_BORROW_MUT: &str = "Vector::borrow_mut";
+pub const EVENT_EMIT_EVENT: &str = "Event::emit_event";
 
 pub const TYPE_NAME_MOVE: &str = "type_info::type_name";
 pub const TYPE_NAME_SPEC: &str = "type_info::$type_name";

--- a/language/move-prover/boogie-backend/src/lib.rs
+++ b/language/move-prover/boogie-backend/src/lib.rs
@@ -48,8 +48,8 @@ const MULTISET_ARRAY_THEORY: &[u8] = include_bytes!("prelude/multiset-array-theo
 const TABLE_ARRAY_THEORY: &[u8] = include_bytes!("prelude/table-array-theory.bpl");
 
 // TODO use named addresses
-const BCS_MODULE: &str = "0x1::bcs";
-const EVENT_MODULE: &str = "0x1::event";
+const BCS_MODULE: &str = "0x1::BCS";
+const EVENT_MODULE: &str = "0x1::Event";
 
 mod boogie_helpers;
 pub mod boogie_wrapper;
@@ -171,11 +171,11 @@ pub fn add_prelude(
     let event_instances = filter_native(EVENT_MODULE);
     context.insert("event_instances", &event_instances);
 
-    // TODO: we have defined {{std}} for adaptable resolution of stdlib addresses but
+    // TODO: we have defined {{Std}} for adaptable resolution of stdlib addresses but
     //   not used it yet in the templates.
     let std_addr = format!("${}", env.get_stdlib_address());
     let ext_addr = format!("${}", env.get_extlib_address());
-    context.insert("std", &std_addr);
+    context.insert("Std", &std_addr);
     context.insert("Ext", &ext_addr);
 
     // If a custom Boogie template is provided, add it as part of the templates and

--- a/language/move-prover/boogie-backend/src/prelude/native.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/native.bpl
@@ -74,27 +74,27 @@ function {:inline} $EmptyVec{{S}}(): Vec ({{T}}) {
     EmptyVec()
 }
 
-procedure {:inline 1} $1_vector_empty{{S}}() returns (v: Vec ({{T}})) {
+procedure {:inline 1} $1_Vector_empty{{S}}() returns (v: Vec ({{T}})) {
     v := EmptyVec();
 }
 
-function {:inline} $1_vector_$empty{{S}}(): Vec ({{T}}) {
+function {:inline} $1_Vector_$empty{{S}}(): Vec ({{T}}) {
     EmptyVec()
 }
 
-procedure {:inline 1} $1_vector_is_empty{{S}}(v: Vec ({{T}})) returns (b: bool) {
+procedure {:inline 1} $1_Vector_is_empty{{S}}(v: Vec ({{T}})) returns (b: bool) {
     b := IsEmptyVec(v);
 }
 
-procedure {:inline 1} $1_vector_push_back{{S}}(m: $Mutation (Vec ({{T}})), val: {{T}}) returns (m': $Mutation (Vec ({{T}}))) {
+procedure {:inline 1} $1_Vector_push_back{{S}}(m: $Mutation (Vec ({{T}})), val: {{T}}) returns (m': $Mutation (Vec ({{T}}))) {
     m' := $UpdateMutation(m, ExtendVec($Dereference(m), val));
 }
 
-function {:inline} $1_vector_$push_back{{S}}(v: Vec ({{T}}), val: {{T}}): Vec ({{T}}) {
+function {:inline} $1_Vector_$push_back{{S}}(v: Vec ({{T}}), val: {{T}}): Vec ({{T}}) {
     ExtendVec(v, val)
 }
 
-procedure {:inline 1} $1_vector_pop_back{{S}}(m: $Mutation (Vec ({{T}}))) returns (e: {{T}}, m': $Mutation (Vec ({{T}}))) {
+procedure {:inline 1} $1_Vector_pop_back{{S}}(m: $Mutation (Vec ({{T}}))) returns (e: {{T}}, m': $Mutation (Vec ({{T}}))) {
     var v: Vec ({{T}});
     var len: int;
     v := $Dereference(m);
@@ -107,23 +107,23 @@ procedure {:inline 1} $1_vector_pop_back{{S}}(m: $Mutation (Vec ({{T}}))) return
     m' := $UpdateMutation(m, RemoveVec(v));
 }
 
-procedure {:inline 1} $1_vector_append{{S}}(m: $Mutation (Vec ({{T}})), other: Vec ({{T}})) returns (m': $Mutation (Vec ({{T}}))) {
+procedure {:inline 1} $1_Vector_append{{S}}(m: $Mutation (Vec ({{T}})), other: Vec ({{T}})) returns (m': $Mutation (Vec ({{T}}))) {
     m' := $UpdateMutation(m, ConcatVec($Dereference(m), other));
 }
 
-procedure {:inline 1} $1_vector_reverse{{S}}(m: $Mutation (Vec ({{T}}))) returns (m': $Mutation (Vec ({{T}}))) {
+procedure {:inline 1} $1_Vector_reverse{{S}}(m: $Mutation (Vec ({{T}}))) returns (m': $Mutation (Vec ({{T}}))) {
     m' := $UpdateMutation(m, ReverseVec($Dereference(m)));
 }
 
-procedure {:inline 1} $1_vector_length{{S}}(v: Vec ({{T}})) returns (l: int) {
+procedure {:inline 1} $1_Vector_length{{S}}(v: Vec ({{T}})) returns (l: int) {
     l := LenVec(v);
 }
 
-function {:inline} $1_vector_$length{{S}}(v: Vec ({{T}})): int {
+function {:inline} $1_Vector_$length{{S}}(v: Vec ({{T}})): int {
     LenVec(v)
 }
 
-procedure {:inline 1} $1_vector_borrow{{S}}(v: Vec ({{T}}), i: int) returns (dst: {{T}}) {
+procedure {:inline 1} $1_Vector_borrow{{S}}(v: Vec ({{T}}), i: int) returns (dst: {{T}}) {
     if (!InRangeVec(v, i)) {
         call $ExecFailureAbort();
         return;
@@ -131,11 +131,11 @@ procedure {:inline 1} $1_vector_borrow{{S}}(v: Vec ({{T}}), i: int) returns (dst
     dst := ReadVec(v, i);
 }
 
-function {:inline} $1_vector_$borrow{{S}}(v: Vec ({{T}}), i: int): {{T}} {
+function {:inline} $1_Vector_$borrow{{S}}(v: Vec ({{T}}), i: int): {{T}} {
     ReadVec(v, i)
 }
 
-procedure {:inline 1} $1_vector_borrow_mut{{S}}(m: $Mutation (Vec ({{T}})), index: int)
+procedure {:inline 1} $1_Vector_borrow_mut{{S}}(m: $Mutation (Vec ({{T}})), index: int)
 returns (dst: $Mutation ({{T}}), m': $Mutation (Vec ({{T}})))
 {
     var v: Vec ({{T}});
@@ -148,17 +148,17 @@ returns (dst: $Mutation ({{T}}), m': $Mutation (Vec ({{T}})))
     m' := m;
 }
 
-function {:inline} $1_vector_$borrow_mut{{S}}(v: Vec ({{T}}), i: int): {{T}} {
+function {:inline} $1_Vector_$borrow_mut{{S}}(v: Vec ({{T}}), i: int): {{T}} {
     ReadVec(v, i)
 }
 
-procedure {:inline 1} $1_vector_destroy_empty{{S}}(v: Vec ({{T}})) {
+procedure {:inline 1} $1_Vector_destroy_empty{{S}}(v: Vec ({{T}})) {
     if (!IsEmptyVec(v)) {
       call $ExecFailureAbort();
     }
 }
 
-procedure {:inline 1} $1_vector_swap{{S}}(m: $Mutation (Vec ({{T}})), i: int, j: int) returns (m': $Mutation (Vec ({{T}})))
+procedure {:inline 1} $1_Vector_swap{{S}}(m: $Mutation (Vec ({{T}})), i: int, j: int) returns (m': $Mutation (Vec ({{T}})))
 {
     var v: Vec ({{T}});
     v := $Dereference(m);
@@ -169,11 +169,11 @@ procedure {:inline 1} $1_vector_swap{{S}}(m: $Mutation (Vec ({{T}})), i: int, j:
     m' := $UpdateMutation(m, SwapVec(v, i, j));
 }
 
-function {:inline} $1_vector_$swap{{S}}(v: Vec ({{T}}), i: int, j: int): Vec ({{T}}) {
+function {:inline} $1_Vector_$swap{{S}}(v: Vec ({{T}}), i: int, j: int): Vec ({{T}}) {
     SwapVec(v, i, j)
 }
 
-procedure {:inline 1} $1_vector_remove{{S}}(m: $Mutation (Vec ({{T}})), i: int) returns (e: {{T}}, m': $Mutation (Vec ({{T}})))
+procedure {:inline 1} $1_Vector_remove{{S}}(m: $Mutation (Vec ({{T}})), i: int) returns (e: {{T}}, m': $Mutation (Vec ({{T}})))
 {
     var v: Vec ({{T}});
 
@@ -187,7 +187,7 @@ procedure {:inline 1} $1_vector_remove{{S}}(m: $Mutation (Vec ({{T}})), i: int) 
     m' := $UpdateMutation(m, RemoveAtVec(v, i));
 }
 
-procedure {:inline 1} $1_vector_swap_remove{{S}}(m: $Mutation (Vec ({{T}})), i: int) returns (e: {{T}}, m': $Mutation (Vec ({{T}})))
+procedure {:inline 1} $1_Vector_swap_remove{{S}}(m: $Mutation (Vec ({{T}})), i: int) returns (e: {{T}}, m': $Mutation (Vec ({{T}})))
 {
     var len: int;
     var v: Vec ({{T}});
@@ -202,12 +202,12 @@ procedure {:inline 1} $1_vector_swap_remove{{S}}(m: $Mutation (Vec ({{T}})), i: 
     m' := $UpdateMutation(m, RemoveVec(SwapVec(v, i, len-1)));
 }
 
-procedure {:inline 1} $1_vector_contains{{S}}(v: Vec ({{T}}), e: {{T}}) returns (res: bool)  {
+procedure {:inline 1} $1_Vector_contains{{S}}(v: Vec ({{T}}), e: {{T}}) returns (res: bool)  {
     res := $ContainsVec{{S}}(v, e);
 }
 
 procedure {:inline 1}
-$1_vector_index_of{{S}}(v: Vec ({{T}}), e: {{T}}) returns (res1: bool, res2: int) {
+$1_Vector_index_of{{S}}(v: Vec ({{T}}), e: {{T}}) returns (res1: bool, res2: int) {
     res2 := $IndexOfVec{{S}}(v, e);
     if (res2 >= 0) {
         res1 := true;
@@ -439,34 +439,34 @@ function {:inline} {{impl.fun_spec_get}}{{S}}(t: {{Self}}, k: {{K}}): {{V}} {
 // Serialize is modeled as an uninterpreted function, with an additional
 // axiom to say it's an injection.
 
-function $1_bcs_serialize{{S}}(v: {{T}}): Vec int;
+function $1_BCS_serialize{{S}}(v: {{T}}): Vec int;
 
-axiom (forall v1, v2: {{T}} :: {$1_bcs_serialize{{S}}(v1), $1_bcs_serialize{{S}}(v2)}
-   $IsEqual{{S}}(v1, v2) <==> $IsEqual'vec'u8''($1_bcs_serialize{{S}}(v1), $1_bcs_serialize{{S}}(v2)));
+axiom (forall v1, v2: {{T}} :: {$1_BCS_serialize{{S}}(v1), $1_BCS_serialize{{S}}(v2)}
+   $IsEqual{{S}}(v1, v2) <==> $IsEqual'vec'u8''($1_BCS_serialize{{S}}(v1), $1_BCS_serialize{{S}}(v2)));
 
 // This says that serialize returns a non-empty vec<u8>
 {% if options.serialize_bound == 0 %}
-axiom (forall v: {{T}} :: {$1_bcs_serialize{{S}}(v)}
-     ( var r := $1_bcs_serialize{{S}}(v); $IsValid'vec'u8''(r) && LenVec(r) > 0 ));
+axiom (forall v: {{T}} :: {$1_BCS_serialize{{S}}(v)}
+     ( var r := $1_BCS_serialize{{S}}(v); $IsValid'vec'u8''(r) && LenVec(r) > 0 ));
 {% else %}
-axiom (forall v: {{T}} :: {$1_bcs_serialize{{S}}(v)}
-     ( var r := $1_bcs_serialize{{S}}(v); $IsValid'vec'u8''(r) && LenVec(r) > 0 &&
+axiom (forall v: {{T}} :: {$1_BCS_serialize{{S}}(v)}
+     ( var r := $1_BCS_serialize{{S}}(v); $IsValid'vec'u8''(r) && LenVec(r) > 0 &&
                             LenVec(r) <= {{options.serialize_bound}} ));
 {% endif %}
 
-procedure $1_bcs_to_bytes{{S}}(v: {{T}}) returns (res: Vec int);
-ensures res == $1_bcs_serialize{{S}}(v);
+procedure $1_BCS_to_bytes{{S}}(v: {{T}}) returns (res: Vec int);
+ensures res == $1_BCS_serialize{{S}}(v);
 
-function {:inline} $1_bcs_$to_bytes{{S}}(v: {{T}}): Vec int {
-    $1_bcs_serialize{{S}}(v)
+function {:inline} $1_BCS_$to_bytes{{S}}(v: {{T}}): Vec int {
+    $1_BCS_serialize{{S}}(v)
 }
 
 {% if S == "'address'" -%}
 // Serialized addresses should have the same length.
 const $serialized_address_len: int;
 // Serialized addresses should have the same length
-axiom (forall v: int :: {$1_bcs_serialize'address'(v)}
-     ( var r := $1_bcs_serialize'address'(v); LenVec(r) == $serialized_address_len));
+axiom (forall v: int :: {$1_BCS_serialize'address'(v)}
+     ( var r := $1_BCS_serialize'address'(v); LenVec(r) == $serialized_address_len));
 {% endif %}
 {% endmacro hash_module %}
 
@@ -480,13 +480,13 @@ axiom (forall v: int :: {$1_bcs_serialize'address'(v)}
 {%- set T = instance.name -%}
 
 // Map type specific handle to universal one.
-type $1_event_EventHandle{{S}} = $1_event_EventHandle;
+type $1_Event_EventHandle{{S}} = $1_Event_EventHandle;
 
-function {:inline} $IsEqual'$1_event_EventHandle{{S}}'(a: $1_event_EventHandle{{S}}, b: $1_event_EventHandle{{S}}): bool {
+function {:inline} $IsEqual'$1_Event_EventHandle{{S}}'(a: $1_Event_EventHandle{{S}}, b: $1_Event_EventHandle{{S}}): bool {
     a == b
 }
 
-function $IsValid'$1_event_EventHandle{{S}}'(h: $1_event_EventHandle{{S}}): bool {
+function $IsValid'$1_Event_EventHandle{{S}}'(h: $1_Event_EventHandle{{S}}): bool {
     true
 }
 
@@ -498,45 +498,45 @@ axiom (forall v1, v2: {{T}} :: {$ToEventRep{{S}}(v1), $ToEventRep{{S}}(v2)}
 // Creates a new event handle. This ensures each time it is called that a unique new abstract event handler is
 // returned.
 // TODO: we should check (and abort with the right code) if no generator exists for the signer.
-procedure {:inline 1} $1_event_new_event_handle{{S}}(signer: $signer) returns (res: $1_event_EventHandle{{S}}) {
-    assume $1_event_EventHandles[res] == false;
-    $1_event_EventHandles := $1_event_EventHandles[res := true];
+procedure {:inline 1} $1_Event_new_event_handle{{S}}(signer: $signer) returns (res: $1_Event_EventHandle{{S}}) {
+    assume $1_Event_EventHandles[res] == false;
+    $1_Event_EventHandles := $1_Event_EventHandles[res := true];
 }
 
 // This boogie procedure is the model of `emit_event`. This model abstracts away the `counter` behavior, thus not
 // mutating (or increasing) `counter`.
-procedure {:inline 1} $1_event_emit_event{{S}}(handle_mut: $Mutation $1_event_EventHandle{{S}}, msg: {{T}})
-returns (res: $Mutation $1_event_EventHandle{{S}}) {
-    var handle: $1_event_EventHandle{{S}};
+procedure {:inline 1} $1_Event_emit_event{{S}}(handle_mut: $Mutation $1_Event_EventHandle{{S}}, msg: {{T}})
+returns (res: $Mutation $1_Event_EventHandle{{S}}) {
+    var handle: $1_Event_EventHandle{{S}};
     handle := $Dereference(handle_mut);
     $es := $ExtendEventStore{{S}}($es, handle, msg);
     res := handle_mut;
 }
 
-procedure {:inline 1} $1_event_guid{{S}}(handle_ref: $1_event_EventHandle{{S}})
+procedure {:inline 1} $1_Event_guid{{S}}(handle_ref: $1_Event_EventHandle{{S}})
 returns (res: int) {
     // TODO: temporarily mocked. The return type needs to be fixed.
     res := 0;
 }
 
-procedure {:inline 1} $1_event_counter{{S}}(handle_ref: $1_event_EventHandle{{S}})
+procedure {:inline 1} $1_Event_counter{{S}}(handle_ref: $1_Event_EventHandle{{S}})
 returns (res: int) {
     // TODO: temporarily mocked.
     res := 0;
 }
 
-procedure {:inline 1} $1_event_destroy_handle{{S}}(handle: $1_event_EventHandle{{S}}) {
+procedure {:inline 1} $1_Event_destroy_handle{{S}}(handle: $1_Event_EventHandle{{S}}) {
 }
 
 function {:inline} $ExtendEventStore{{S}}(
-        es: $EventStore, handle: $1_event_EventHandle{{S}}, msg: {{T}}): $EventStore {
+        es: $EventStore, handle: $1_Event_EventHandle{{S}}, msg: {{T}}): $EventStore {
     (var stream := streams#$EventStore(es)[handle];
     (var stream_new := ExtendMultiset(stream, $ToEventRep{{S}}(msg));
     $EventStore(counter#$EventStore(es)+1, streams#$EventStore(es)[handle := stream_new])))
 }
 
 function {:inline} $CondExtendEventStore{{S}}(
-        es: $EventStore, handle: $1_event_EventHandle{{S}}, msg: {{T}}, cond: bool): $EventStore {
+        es: $EventStore, handle: $1_Event_EventHandle{{S}}, msg: {{T}}, cond: bool): $EventStore {
     if cond then
         $ExtendEventStore{{S}}(es, handle, msg)
     else

--- a/language/move-prover/boogie-backend/src/prelude/prelude.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/prelude.bpl
@@ -798,36 +798,36 @@ function {:inline} $SliceVecByRange<T>(v: Vec T, r: $Range): Vec T {
 // assert that sha2/3 are injections without using global quantified axioms.
 
 
-function $1_hash_sha2(val: Vec int): Vec int;
+function $1_Hash_sha2(val: Vec int): Vec int;
 
 // This says that Hash_sha2 is bijective.
-axiom (forall v1,v2: Vec int :: {$1_hash_sha2(v1), $1_hash_sha2(v2)}
-       $IsEqual'vec'u8''(v1, v2) <==> $IsEqual'vec'u8''($1_hash_sha2(v1), $1_hash_sha2(v2)));
+axiom (forall v1,v2: Vec int :: {$1_Hash_sha2(v1), $1_Hash_sha2(v2)}
+       $IsEqual'vec'u8''(v1, v2) <==> $IsEqual'vec'u8''($1_Hash_sha2(v1), $1_Hash_sha2(v2)));
 
-procedure $1_hash_sha2_256(val: Vec int) returns (res: Vec int);
-ensures res == $1_hash_sha2(val);     // returns Hash_sha2 Value
+procedure $1_Hash_sha2_256(val: Vec int) returns (res: Vec int);
+ensures res == $1_Hash_sha2(val);     // returns Hash_sha2 Value
 ensures $IsValid'vec'u8''(res);    // result is a legal vector of U8s.
 ensures LenVec(res) == 32;               // result is 32 bytes.
 
 // Spec version of Move native function.
-function {:inline} $1_hash_$sha2_256(val: Vec int): Vec int {
-    $1_hash_sha2(val)
+function {:inline} $1_Hash_$sha2_256(val: Vec int): Vec int {
+    $1_Hash_sha2(val)
 }
 
 // similarly for Hash_sha3
-function $1_hash_sha3(val: Vec int): Vec int;
+function $1_Hash_sha3(val: Vec int): Vec int;
 
-axiom (forall v1,v2: Vec int :: {$1_hash_sha3(v1), $1_hash_sha3(v2)}
-       $IsEqual'vec'u8''(v1, v2) <==> $IsEqual'vec'u8''($1_hash_sha3(v1), $1_hash_sha3(v2)));
+axiom (forall v1,v2: Vec int :: {$1_Hash_sha3(v1), $1_Hash_sha3(v2)}
+       $IsEqual'vec'u8''(v1, v2) <==> $IsEqual'vec'u8''($1_Hash_sha3(v1), $1_Hash_sha3(v2)));
 
-procedure $1_hash_sha3_256(val: Vec int) returns (res: Vec int);
-ensures res == $1_hash_sha3(val);     // returns Hash_sha3 Value
+procedure $1_Hash_sha3_256(val: Vec int) returns (res: Vec int);
+ensures res == $1_Hash_sha3(val);     // returns Hash_sha3 Value
 ensures $IsValid'vec'u8''(res);    // result is a legal vector of U8s.
 ensures LenVec(res) == 32;               // result is 32 bytes.
 
 // Spec version of Move native function.
-function {:inline} $1_hash_$sha3_256(val: Vec int): Vec int {
-    $1_hash_sha3(val)
+function {:inline} $1_Hash_$sha3_256(val: Vec int): Vec int {
+    $1_Hash_sha3(val)
 }
 
 // ==================================================================================
@@ -888,18 +888,18 @@ function {:inline} $IsEqual'signer'(s1: $signer, s2: $signer): bool {
     s1 == s2
 }
 
-procedure {:inline 1} $1_signer_borrow_address(signer: $signer) returns (res: int) {
+procedure {:inline 1} $1_Signer_borrow_address(signer: $signer) returns (res: int) {
     res := $addr#$signer(signer);
 }
 
-function {:inline} $1_signer_$borrow_address(signer: $signer): int
+function {:inline} $1_Signer_$borrow_address(signer: $signer): int
 {
     $addr#$signer(signer)
 }
 
-function $1_signer_is_txn_signer(s: $signer): bool;
+function $1_Signer_is_txn_signer(s: $signer): bool;
 
-function $1_signer_is_txn_signer_addr(a: int): bool;
+function $1_Signer_is_txn_signer_addr(a: int): bool;
 
 
 // ==================================================================================
@@ -933,7 +933,7 @@ procedure {:inline 1} $1_Signature_ed25519_verify(
 
 
 // ==================================================================================
-// Native bcs::serialize
+// Native BCS::serialize
 
 {%- for instance in bcs_instances %}
 
@@ -970,14 +970,14 @@ procedure {:inline 1} $1_Event_publish_generator(signer: $signer) {
 
 
 // Generic code for dealing with mutations (havoc) still requires type and memory declarations.
-type $1_event_EventHandleGenerator;
-var $1_event_EventHandleGenerator_$memory: $Memory $1_event_EventHandleGenerator;
+type $1_Event_EventHandleGenerator;
+var $1_Event_EventHandleGenerator_$memory: $Memory $1_Event_EventHandleGenerator;
 
 // Abstract type of event handles.
-type $1_event_EventHandle;
+type $1_Event_EventHandle;
 
 // Global state to implement uniqueness of event handles.
-var $1_event_EventHandles: [$1_event_EventHandle]bool;
+var $1_Event_EventHandles: [$1_Event_EventHandle]bool;
 
 // Universal representation of an an event. For each concrete event type, we generate a constructor.
 type {:datatype} $EventRep;
@@ -985,7 +985,7 @@ type {:datatype} $EventRep;
 // Representation of EventStore that consists of event streams.
 type {:datatype} $EventStore;
 function {:constructor} $EventStore(
-    counter: int, streams: [$1_event_EventHandle]Multiset $EventRep): $EventStore;
+    counter: int, streams: [$1_Event_EventHandle]Multiset $EventRep): $EventStore;
 
 // Global state holding EventStore.
 var $es: $EventStore;
@@ -996,7 +996,7 @@ procedure {:inline 1} $InitEventStore() {
 
 function {:inline} $EventStore__is_empty(es: $EventStore): bool {
     (counter#$EventStore(es) == 0) &&
-    (forall handle: $1_event_EventHandle ::
+    (forall handle: $1_Event_EventHandle ::
         (var stream := streams#$EventStore(es)[handle];
         IsEmptyMultiset(stream)))
 }
@@ -1004,7 +1004,7 @@ function {:inline} $EventStore__is_empty(es: $EventStore): bool {
 // This function returns (es1 - es2). This function assumes that es2 is a subset of es1.
 function {:inline} $EventStore__subtract(es1: $EventStore, es2: $EventStore): $EventStore {
     $EventStore(counter#$EventStore(es1)-counter#$EventStore(es2),
-        (lambda handle: $1_event_EventHandle ::
+        (lambda handle: $1_Event_EventHandle ::
         SubtractMultiset(
             streams#$EventStore(es1)[handle],
             streams#$EventStore(es2)[handle])))
@@ -1012,7 +1012,7 @@ function {:inline} $EventStore__subtract(es1: $EventStore, es2: $EventStore): $E
 
 function {:inline} $EventStore__is_subset(es1: $EventStore, es2: $EventStore): bool {
     (counter#$EventStore(es1) <= counter#$EventStore(es2)) &&
-    (forall handle: $1_event_EventHandle ::
+    (forall handle: $1_Event_EventHandle ::
         IsSubsetMultiset(
             streams#$EventStore(es1)[handle],
             streams#$EventStore(es2)[handle]

--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -1513,12 +1513,12 @@ impl<'env> SpecTranslator<'env> {
                     };
                     emit!(
                         self.writer,
-                        &format!(" && $1_signer_is_txn_signer({})", target)
+                        &format!(" && $1_Signer_is_txn_signer({})", target)
                     );
                     emit!(
                         self.writer,
                         &format!(
-                            " && $1_signer_is_txn_signer_addr($addr#$signer({}))",
+                            " && $1_Signer_is_txn_signer_addr($addr#$signer({}))",
                             target
                         )
                     );

--- a/language/move-prover/bytecode/src/escape_analysis.rs
+++ b/language/move-prover/bytecode/src/escape_analysis.rs
@@ -263,7 +263,7 @@ impl<'a> TransferFunctions for EscapeAnalysis<'a> {
                             callee_fun_env.module_env.get_identifier().as_str(),
                             callee_fun_env.get_identifier().as_str(),
                         ) {
-                            ("vector", "borrow_mut") | ("vector", "borrow") => {
+                            ("Vector", "borrow_mut") | ("Vector", "borrow") => {
                                 let vec_arg = 0;
                                 let to_propagate = match state.get_local_index(&args[vec_arg]) {
                                     AbsValue::OkRef => {

--- a/language/move-prover/bytecode/src/read_write_set_analysis.rs
+++ b/language/move-prover/bytecode/src/read_write_set_analysis.rs
@@ -621,30 +621,30 @@ fn call_native_function(
 ) {
     // native fun. use handwritten model
     match (module_name, fun_name) {
-        ("bcs", "to_bytes") => {
+        ("BCS", "to_bytes") => {
             if state.locals.local_exists(args[0], func_env) {
                 state.record_access(args[0], Access::Read, func_env)
             }
         }
-        ("signer", "borrow_address") => {
+        ("Signer", "borrow_address") => {
             if state.locals.local_exists(args[0], func_env) {
                 // treat as identity function
                 state.assign_local(rets[0], args[0], func_env)
             }
         }
-        ("vector", "borrow_mut") | ("vector", "borrow") => {
+        ("Vector", "borrow_mut") | ("Vector", "borrow") => {
             if state.locals.local_exists(args[0], func_env) {
                 // this will look at vector length. record as read of an index
                 state.access_offset(args[0], Offset::VectorIndex, Access::Read, func_env);
                 state.assign_offset(rets[0], args[0], Offset::VectorIndex, None, func_env)
             }
         }
-        ("vector", "length") | ("vector", "is_empty") => {
+        ("Vector", "length") | ("Vector", "is_empty") => {
             if state.locals.local_exists(args[0], func_env) {
                 state.record_access(args[0], Access::Read, func_env)
             }
         }
-        ("vector", "pop_back") => {
+        ("Vector", "pop_back") => {
             if state.locals.local_exists(args[0], func_env) {
                 // this will look at vector length. record as read of an index
                 state.access_offset(args[0], Offset::VectorIndex, Access::Read, func_env);
@@ -658,7 +658,7 @@ fn call_native_function(
                 )
             }
         }
-        ("vector", "push_back") | ("vector", "append") | ("vector", "swap") => {
+        ("Vector", "push_back") | ("Vector", "append") | ("Vector", "swap") => {
             if state.locals.local_exists(args[0], func_env) {
                 // this will look at vector length. record as read of an index
                 state.access_offset(args[0], Offset::VectorIndex, Access::Read, func_env);
@@ -666,7 +666,7 @@ fn call_native_function(
                 state.access_offset(args[0], Offset::VectorIndex, Access::Write, func_env);
             }
         }
-        ("vector", "contains") => {
+        ("Vector", "contains") => {
             if state.locals.local_exists(args[0], func_env) {
                 state.record_access(args[0], Access::Read, func_env); // reads the length + contents
             }
@@ -685,13 +685,13 @@ fn call_native_function(
                 state.assign_local(rets[0], args[0], func_env)
             }
         }
-        ("vector", "empty") | ("vector", "destroy_empty") | ("vector", "reverse") => (),
-        ("string", "internal_check_utf8")
-        | ("string", "internal_is_char_boundary")
-        | ("string", "internal_sub_string")
-        | ("string", "internal_index_of") => (),
-        ("event", "write_to_event_store") => (),
-        ("hash", "sha3_256") | ("hash", "sha2_256") => (),
+        ("Vector", "empty") | ("Vector", "destroy_empty") | ("Vector", "reverse") => (),
+        ("String", "internal_check_utf8")
+        | ("String", "internal_is_char_boundary")
+        | ("String", "internal_sub_string")
+        | ("String", "internal_index_of") => (),
+        ("Event", "write_to_event_store") => (),
+        ("Hash", "sha3_256") | ("Hash", "sha2_256") => (),
         ("Signature", "ed25519_validate_pubkey") | ("Signature", "ed25519_verify") => (),
         (m, f) => {
             panic!("Unsupported native function {:?}::{:?}", m, f)

--- a/language/move-prover/bytecode/src/stackless_bytecode_generator.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode_generator.rs
@@ -203,7 +203,7 @@ impl<'a> StacklessBytecodeGenerator<'a> {
             let vec_module_env = vec_module_id_opt.get_or_insert_with(|| {
                 let vec_module = global_env.to_module_name(&language_storage::ModuleId::new(
                     CORE_CODE_ADDRESS,
-                    move_core_types::identifier::Identifier::new("vector").unwrap(),
+                    move_core_types::identifier::Identifier::new("Vector").unwrap(),
                 ));
                 global_env
                     .find_module(&vec_module)


### PR DESCRIPTION
## Motivation
To support lower case module names, some changes of Move Prover that are incompatible with Starcoin were introduced. This patch solves this problem.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

Yes.

## Test Plan
Test with `mpm package prove`.

Note that this is the first half of the changes. StarcoinFramework itself need to be fixed too.