### PR TITLE
fix(vm-types): support delayed-field serde for decorated struct layouts

### DIFF
--- a/language/move-vm/types/src/value_serde.rs
+++ b/language/move-vm/types/src/value_serde.rs
@@ -22,7 +22,7 @@ use std::cell::RefCell;
 /// An extension to (de)serialize information about function values.
 ///
 /// Starcoin's current Move revision does not serialize function values yet, but this trait and the
-/// context method are kept to align call sites with Aptos style APIs.
+/// context method are kept to align call sites with the unified serde APIs.
 pub trait FunctionValueExtension {
     fn max_value_nest_depth(&self) -> Option<u64>;
 }
@@ -186,7 +186,7 @@ enum DelayedFieldsMode<'a, I: From<u64> + ExtractWidth + ExtractUniqueIndex> {
     Replacement(&'a dyn ValueToIdentifierMapping<Identifier = I>),
 }
 
-/// Aptos-style serde context that keeps delayed-field behavior explicit at call sites.
+/// Serde context that keeps delayed-field behavior explicit at call sites.
 pub struct ValueSerDeContext<'a, I: From<u64> + ExtractWidth + ExtractUniqueIndex = DelayedFieldID>
 {
     delayed_fields_mode: DelayedFieldsMode<'a, I>,
@@ -202,7 +202,7 @@ impl<'a, I: From<u64> + ExtractWidth + ExtractUniqueIndex> ValueSerDeContext<'a,
         }
     }
 
-    /// Keep API compatibility with Aptos-style call chains.
+    /// Keep API compatibility with the serde context call chains.
     pub fn with_func_args_deserialization(
         mut self,
         extension: &'a dyn FunctionValueExtension,

--- a/language/move-vm/types/src/value_serde.rs
+++ b/language/move-vm/types/src/value_serde.rs
@@ -338,7 +338,7 @@ impl<'a, I: From<u64> + ExtractWidth + ExtractUniqueIndex> CustomDeserializer
 pub fn deserialize_and_replace_values_with_ids<I: From<u64> + ExtractWidth + ExtractUniqueIndex>(
     bytes: &[u8],
     layout: &MoveTypeLayout,
-    mapping: &impl ValueToIdentifierMapping<Identifier = I>,
+    mapping: &dyn ValueToIdentifierMapping<Identifier = I>,
 ) -> Option<Value> {
     let custom_deserializer = CustomSerDeWithExchange::new(mapping);
     let seed = DeserializationSeed {
@@ -355,7 +355,7 @@ pub fn deserialize_and_replace_values_with_ids<I: From<u64> + ExtractWidth + Ext
 pub fn serialize_and_replace_ids_with_values<I: From<u64> + ExtractWidth + ExtractUniqueIndex>(
     value: &Value,
     layout: &MoveTypeLayout,
-    mapping: &impl ValueToIdentifierMapping<Identifier = I>,
+    mapping: &dyn ValueToIdentifierMapping<Identifier = I>,
 ) -> Option<Vec<u8>> {
     let custom_serializer = CustomSerDeWithExchange::new(mapping);
     let value = SerializationReadyValue {

--- a/language/move-vm/types/src/value_serde.rs
+++ b/language/move-vm/types/src/value_serde.rs
@@ -112,6 +112,8 @@ impl CustomSerializer for RelaxedCustomSerDe {
             custom_serializer: None::<&RelaxedCustomSerDe>,
             layout,
             value: &value.0,
+            max_value_nest_depth: None,
+            depth: 1,
         }
         .serialize(serializer)
     }
@@ -137,11 +139,21 @@ pub fn serialize_and_allow_delayed_values(
     value: &Value,
     layout: &MoveTypeLayout,
 ) -> PartialVMResult<Option<Vec<u8>>> {
+    serialize_and_allow_delayed_values_with_limit(value, layout, None)
+}
+
+fn serialize_and_allow_delayed_values_with_limit(
+    value: &Value,
+    layout: &MoveTypeLayout,
+    max_value_nest_depth: Option<u64>,
+) -> PartialVMResult<Option<Vec<u8>>> {
     let native_serializer = RelaxedCustomSerDe::new();
     let value = SerializationReadyValue {
         custom_serializer: Some(&native_serializer),
         layout,
         value: &value.0,
+        max_value_nest_depth,
+        depth: 1,
     };
     bcs::to_bytes(&value)
         .ok()
@@ -180,16 +192,18 @@ pub trait ValueToIdentifierMapping {
     ) -> PartialVMResult<Value>;
 }
 
-enum DelayedFieldsMode<'a, I: From<u64> + ExtractWidth + ExtractUniqueIndex> {
-    Disabled,
-    Serde,
-    Replacement(&'a dyn ValueToIdentifierMapping<Identifier = I>),
+/// Aptos-style delayed fields extension:
+/// - `None`: delayed fields are disabled.
+/// - `Some { mapping: None }`: delayed values are (de)serialized as ids.
+/// - `Some { mapping: Some(..) }`: delayed ids are exchanged with values.
+struct DelayedFieldsExtension<'a, I: From<u64> + ExtractWidth + ExtractUniqueIndex> {
+    mapping: Option<&'a dyn ValueToIdentifierMapping<Identifier = I>>,
 }
 
 /// Serde context that keeps delayed-field behavior explicit at call sites.
 pub struct ValueSerDeContext<'a, I: From<u64> + ExtractWidth + ExtractUniqueIndex = DelayedFieldID>
 {
-    delayed_fields_mode: DelayedFieldsMode<'a, I>,
+    delayed_fields_extension: Option<DelayedFieldsExtension<'a, I>>,
     max_value_nested_depth: Option<u64>,
 }
 
@@ -197,7 +211,7 @@ impl<'a, I: From<u64> + ExtractWidth + ExtractUniqueIndex> ValueSerDeContext<'a,
     /// Default (de)serializer that disallows delayed fields.
     pub fn new(max_value_nested_depth: Option<u64>) -> Self {
         Self {
-            delayed_fields_mode: DelayedFieldsMode::Disabled,
+            delayed_fields_extension: None,
             max_value_nested_depth,
         }
     }
@@ -215,7 +229,7 @@ impl<'a, I: From<u64> + ExtractWidth + ExtractUniqueIndex> ValueSerDeContext<'a,
 
     /// Allow delayed values to be (de)serialized as delayed ids.
     pub fn with_delayed_fields_serde(mut self) -> Self {
-        self.delayed_fields_mode = DelayedFieldsMode::Serde;
+        self.delayed_fields_extension = Some(DelayedFieldsExtension { mapping: None });
         self
     }
 
@@ -225,42 +239,62 @@ impl<'a, I: From<u64> + ExtractWidth + ExtractUniqueIndex> ValueSerDeContext<'a,
         mut self,
         mapping: &'a dyn ValueToIdentifierMapping<Identifier = I>,
     ) -> Self {
-        self.delayed_fields_mode = DelayedFieldsMode::Replacement(mapping);
+        self.delayed_fields_extension = Some(DelayedFieldsExtension {
+            mapping: Some(mapping),
+        });
         self
     }
 
-    pub fn serialize(self, value: &Value, layout: &MoveTypeLayout) -> PartialVMResult<Option<Vec<u8>>> {
-        let _ = self.max_value_nested_depth;
-        match self.delayed_fields_mode {
-            DelayedFieldsMode::Disabled => {
+    pub fn serialize(
+        self,
+        value: &Value,
+        layout: &MoveTypeLayout,
+    ) -> PartialVMResult<Option<Vec<u8>>> {
+        match self.delayed_fields_extension {
+            None => {
                 let ready = SerializationReadyValue {
                     custom_serializer: None::<&RelaxedCustomSerDe>,
                     layout,
                     value: &value.0,
+                    max_value_nest_depth: self.max_value_nested_depth,
+                    depth: 1,
                 };
                 Ok(bcs::to_bytes(&ready).ok())
             }
-            DelayedFieldsMode::Serde => serialize_and_allow_delayed_values(value, layout),
-            DelayedFieldsMode::Replacement(mapping) => {
-                Ok(serialize_and_replace_ids_with_values(value, layout, mapping))
+            Some(DelayedFieldsExtension { mapping: None }) => {
+                serialize_and_allow_delayed_values_with_limit(
+                    value,
+                    layout,
+                    self.max_value_nested_depth,
+                )
             }
+            Some(DelayedFieldsExtension {
+                mapping: Some(mapping),
+            }) => Ok(serialize_and_replace_ids_with_values_with_limit(
+                value,
+                layout,
+                mapping,
+                self.max_value_nested_depth,
+            )),
         }
     }
 
     pub fn deserialize(self, bytes: &[u8], layout: &MoveTypeLayout) -> Option<Value> {
         let _ = self.max_value_nested_depth;
-        match self.delayed_fields_mode {
-            DelayedFieldsMode::Disabled => {
+        match self.delayed_fields_extension {
+            None => {
                 let seed = DeserializationSeed {
                     custom_deserializer: None::<&RelaxedCustomSerDe>,
                     layout,
                 };
                 bcs::from_bytes_seed(seed, bytes).ok()
             }
-            DelayedFieldsMode::Serde => deserialize_and_allow_delayed_values(bytes, layout),
-            DelayedFieldsMode::Replacement(mapping) => {
-                deserialize_and_replace_values_with_ids(bytes, layout, mapping)
+            Some(DelayedFieldsExtension { mapping: None }) => {
+                deserialize_and_allow_delayed_values(bytes, layout)
             }
+            Some(DelayedFieldsExtension {
+                mapping: Some(mapping),
+            }) => deserialize_and_replace_values_with_ids(bytes, layout, mapping),
         }
     }
 }
@@ -303,6 +337,8 @@ impl<'a, I: From<u64> + ExtractWidth + ExtractUniqueIndex> CustomSerializer
             custom_serializer: None::<&RelaxedCustomSerDe>,
             layout,
             value: &value.0,
+            max_value_nest_depth: None,
+            depth: 1,
         }
         .serialize(serializer)
     }
@@ -357,11 +393,24 @@ pub fn serialize_and_replace_ids_with_values<I: From<u64> + ExtractWidth + Extra
     layout: &MoveTypeLayout,
     mapping: &dyn ValueToIdentifierMapping<Identifier = I>,
 ) -> Option<Vec<u8>> {
+    serialize_and_replace_ids_with_values_with_limit(value, layout, mapping, None)
+}
+
+fn serialize_and_replace_ids_with_values_with_limit<
+    I: From<u64> + ExtractWidth + ExtractUniqueIndex,
+>(
+    value: &Value,
+    layout: &MoveTypeLayout,
+    mapping: &dyn ValueToIdentifierMapping<Identifier = I>,
+    max_value_nest_depth: Option<u64>,
+) -> Option<Vec<u8>> {
     let custom_serializer = CustomSerDeWithExchange::new(mapping);
     let value = SerializationReadyValue {
         custom_serializer: Some(&custom_serializer),
         layout,
         value: &value.0,
+        max_value_nest_depth,
+        depth: 1,
     };
     bcs::to_bytes(&value).ok().filter(|_| {
         // Should never happen, it should always fail first in serialize_and_allow_delayed_values

--- a/language/move-vm/types/src/value_serde.rs
+++ b/language/move-vm/types/src/value_serde.rs
@@ -19,6 +19,14 @@ use serde::{
 };
 use std::cell::RefCell;
 
+/// An extension to (de)serialize information about function values.
+///
+/// Starcoin's current Move revision does not serialize function values yet, but this trait and the
+/// context method are kept to align call sites with Aptos style APIs.
+pub trait FunctionValueExtension {
+    fn max_value_nest_depth(&self) -> Option<u64>;
+}
+
 pub trait CustomDeserializer {
     fn custom_deserialize<'d, D: Deserializer<'d>>(
         &self,
@@ -170,6 +178,91 @@ pub trait ValueToIdentifierMapping {
         layout: &MoveTypeLayout,
         identifier: Self::Identifier,
     ) -> PartialVMResult<Value>;
+}
+
+enum DelayedFieldsMode<'a, I: From<u64> + ExtractWidth + ExtractUniqueIndex> {
+    Disabled,
+    Serde,
+    Replacement(&'a dyn ValueToIdentifierMapping<Identifier = I>),
+}
+
+/// Aptos-style serde context that keeps delayed-field behavior explicit at call sites.
+pub struct ValueSerDeContext<'a, I: From<u64> + ExtractWidth + ExtractUniqueIndex = DelayedFieldID>
+{
+    delayed_fields_mode: DelayedFieldsMode<'a, I>,
+    max_value_nested_depth: Option<u64>,
+}
+
+impl<'a, I: From<u64> + ExtractWidth + ExtractUniqueIndex> ValueSerDeContext<'a, I> {
+    /// Default (de)serializer that disallows delayed fields.
+    pub fn new(max_value_nested_depth: Option<u64>) -> Self {
+        Self {
+            delayed_fields_mode: DelayedFieldsMode::Disabled,
+            max_value_nested_depth,
+        }
+    }
+
+    /// Keep API compatibility with Aptos-style call chains.
+    pub fn with_func_args_deserialization(
+        mut self,
+        extension: &'a dyn FunctionValueExtension,
+    ) -> Self {
+        if self.max_value_nested_depth.is_none() {
+            self.max_value_nested_depth = extension.max_value_nest_depth();
+        }
+        self
+    }
+
+    /// Allow delayed values to be (de)serialized as delayed ids.
+    pub fn with_delayed_fields_serde(mut self) -> Self {
+        self.delayed_fields_mode = DelayedFieldsMode::Serde;
+        self
+    }
+
+    /// Replace delayed ids with values on serialization, and values with delayed ids on
+    /// deserialization.
+    pub fn with_delayed_fields_replacement(
+        mut self,
+        mapping: &'a dyn ValueToIdentifierMapping<Identifier = I>,
+    ) -> Self {
+        self.delayed_fields_mode = DelayedFieldsMode::Replacement(mapping);
+        self
+    }
+
+    pub fn serialize(self, value: &Value, layout: &MoveTypeLayout) -> PartialVMResult<Option<Vec<u8>>> {
+        let _ = self.max_value_nested_depth;
+        match self.delayed_fields_mode {
+            DelayedFieldsMode::Disabled => {
+                let ready = SerializationReadyValue {
+                    custom_serializer: None::<&RelaxedCustomSerDe>,
+                    layout,
+                    value: &value.0,
+                };
+                Ok(bcs::to_bytes(&ready).ok())
+            }
+            DelayedFieldsMode::Serde => serialize_and_allow_delayed_values(value, layout),
+            DelayedFieldsMode::Replacement(mapping) => {
+                Ok(serialize_and_replace_ids_with_values(value, layout, mapping))
+            }
+        }
+    }
+
+    pub fn deserialize(self, bytes: &[u8], layout: &MoveTypeLayout) -> Option<Value> {
+        let _ = self.max_value_nested_depth;
+        match self.delayed_fields_mode {
+            DelayedFieldsMode::Disabled => {
+                let seed = DeserializationSeed {
+                    custom_deserializer: None::<&RelaxedCustomSerDe>,
+                    layout,
+                };
+                bcs::from_bytes_seed(seed, bytes).ok()
+            }
+            DelayedFieldsMode::Serde => deserialize_and_allow_delayed_values(bytes, layout),
+            DelayedFieldsMode::Replacement(mapping) => {
+                deserialize_and_replace_values_with_ids(bytes, layout, mapping)
+            }
+        }
+    }
 }
 
 /// Custom (de)serializer such that:

--- a/language/move-vm/types/src/value_serde.rs
+++ b/language/move-vm/types/src/value_serde.rs
@@ -5,11 +5,11 @@ use crate::{
     delayed_values::delayed_field_id::{
         DelayedFieldID, ExtractUniqueIndex, ExtractWidth, TryFromMoveValue, TryIntoMoveValue,
     },
-    values::{DeserializationSeed, SerializationReadyValue, Value},
+    values::{DeserializationSeed, SerializationReadyValue, Struct, Value},
 };
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
-    value::{IdentifierMappingKind, MoveTypeLayout},
+    value::{IdentifierMappingKind, MoveStructLayout, MoveTypeLayout},
     vm_status::StatusCode,
 };
 use serde::{
@@ -190,6 +190,117 @@ pub trait ValueToIdentifierMapping {
         layout: &MoveTypeLayout,
         identifier: Self::Identifier,
     ) -> PartialVMResult<Value>;
+}
+
+fn struct_field_layouts(struct_layout: &MoveStructLayout) -> Vec<&MoveTypeLayout> {
+    match struct_layout {
+        MoveStructLayout::Runtime(fields) => fields.iter().collect(),
+        MoveStructLayout::WithFields(fields) => fields.iter().map(|field| &field.layout).collect(),
+        MoveStructLayout::WithTypes { fields, .. } => {
+            fields.iter().map(|field| &field.layout).collect()
+        }
+    }
+}
+
+fn nested_native_integer_exchange_info(
+    layout: &MoveTypeLayout,
+) -> Option<(IdentifierMappingKind, MoveTypeLayout, u32)> {
+    let outer = match layout {
+        MoveTypeLayout::Struct(s) => s,
+        _ => return None,
+    };
+    let outer_fields = struct_field_layouts(outer);
+    if outer_fields.len() != 1 {
+        return None;
+    }
+
+    let inner = match outer_fields[0] {
+        MoveTypeLayout::Struct(s) => s,
+        _ => return None,
+    };
+    let inner_fields = struct_field_layouts(inner);
+    if inner_fields.len() != 2 {
+        return None;
+    }
+
+    let (kind, inner_layout, width) = match inner_fields[0] {
+        MoveTypeLayout::Native(kind, inner_layout) => match inner_layout.as_ref() {
+            MoveTypeLayout::U64 => (kind.clone(), MoveTypeLayout::U64, 8),
+            MoveTypeLayout::U128 => (kind.clone(), MoveTypeLayout::U128, 16),
+            _ => return None,
+        },
+        _ => return None,
+    };
+
+    if inner_fields[1] != &inner_layout {
+        return None;
+    }
+
+    match kind {
+        IdentifierMappingKind::Aggregator | IdentifierMappingKind::Snapshot => {
+            Some((kind, inner_layout, width))
+        }
+        _ => None,
+    }
+}
+
+fn try_deserialize_nested_native_integer_with_exchange<
+    I: From<u64> + ExtractWidth + ExtractUniqueIndex,
+>(
+    bytes: &[u8],
+    layout: &MoveTypeLayout,
+    mapping: &dyn ValueToIdentifierMapping<Identifier = I>,
+) -> Option<PartialVMResult<Value>> {
+    let (kind, inner_layout, expected_width) = nested_native_integer_exchange_info(layout)?;
+    let width = usize::try_from(expected_width).ok()?;
+    if bytes.len() != width.saturating_mul(2) {
+        return None;
+    }
+
+    let (base_value, max_value) = match inner_layout {
+        MoveTypeLayout::U64 => {
+            let mut base = [0u8; 8];
+            base.copy_from_slice(&bytes[..8]);
+            let mut max = [0u8; 8];
+            max.copy_from_slice(&bytes[8..16]);
+            (
+                Value::u64(u64::from_le_bytes(base)),
+                Value::u64(u64::from_le_bytes(max)),
+            )
+        }
+        MoveTypeLayout::U128 => {
+            let mut base = [0u8; 16];
+            base.copy_from_slice(&bytes[..16]);
+            let mut max = [0u8; 16];
+            max.copy_from_slice(&bytes[16..32]);
+            (
+                Value::u128(u128::from_le_bytes(base)),
+                Value::u128(u128::from_le_bytes(max)),
+            )
+        }
+        _ => return None,
+    };
+
+    let id = match mapping.value_to_identifier(&kind, &inner_layout, base_value) {
+        Ok(id) => id,
+        Err(err) => return Some(Err(err)),
+    };
+
+    if id.extract_width() != expected_width {
+        return Some(Err(PartialVMError::new(StatusCode::VM_EXTENSION_ERROR)
+            .with_message(format!(
+                "Nested native integer exchange width mismatch: expected {}, got {}",
+                expected_width,
+                id.extract_width()
+            ))));
+    }
+
+    let delayed = Value::delayed_value(DelayedFieldID::new_with_width(
+        id.extract_unique_index(),
+        id.extract_width(),
+    ));
+    let inner = Value::struct_(Struct::pack([delayed, max_value]));
+    Some(Ok(Value::struct_(Struct::pack([inner]))))
 }
 
 /// Aptos-style delayed fields extension:
@@ -376,6 +487,12 @@ pub fn deserialize_and_replace_values_with_ids<I: From<u64> + ExtractWidth + Ext
     layout: &MoveTypeLayout,
     mapping: &dyn ValueToIdentifierMapping<Identifier = I>,
 ) -> Option<Value> {
+    if let Some(result) =
+        try_deserialize_nested_native_integer_with_exchange(bytes, layout, mapping)
+    {
+        return result.ok();
+    }
+
     let custom_deserializer = CustomSerDeWithExchange::new(mapping);
     let seed = DeserializationSeed {
         custom_deserializer: Some(&custom_deserializer),
@@ -417,4 +534,117 @@ fn serialize_and_replace_ids_with_values_with_limit<
         // so we can treat it as regular deserialization error.
         custom_serializer.delayed_fields_count.into_inner() <= MAX_DELAYED_FIELDS_PER_RESOURCE
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    struct RecordingMapping {
+        expected_kind: IdentifierMappingKind,
+        expected_layout: MoveTypeLayout,
+        returned_id: DelayedFieldID,
+        seen_values: RefCell<Vec<u128>>,
+    }
+
+    impl ValueToIdentifierMapping for RecordingMapping {
+        type Identifier = DelayedFieldID;
+
+        fn value_to_identifier(
+            &self,
+            kind: &IdentifierMappingKind,
+            layout: &MoveTypeLayout,
+            value: Value,
+        ) -> PartialVMResult<Self::Identifier> {
+            assert_eq!(kind, &self.expected_kind);
+            assert_eq!(layout, &self.expected_layout);
+            let v = match layout {
+                MoveTypeLayout::U64 => value.value_as::<u64>()? as u128,
+                MoveTypeLayout::U128 => value.value_as::<u128>()?,
+                _ => panic!("unexpected layout"),
+            };
+            self.seen_values.borrow_mut().push(v);
+            Ok(self.returned_id)
+        }
+
+        fn identifier_to_value(
+            &self,
+            _layout: &MoveTypeLayout,
+            _identifier: Self::Identifier,
+        ) -> PartialVMResult<Value> {
+            unreachable!()
+        }
+    }
+
+    fn nested_layout(kind: IdentifierMappingKind, inner: MoveTypeLayout) -> MoveTypeLayout {
+        MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![MoveTypeLayout::Struct(
+            MoveStructLayout::Runtime(vec![
+                MoveTypeLayout::Native(kind, Box::new(inner.clone())),
+                inner,
+            ]),
+        )]))
+    }
+
+    #[test]
+    fn replace_values_with_ids_nested_native_u64() {
+        let layout = nested_layout(IdentifierMappingKind::Aggregator, MoveTypeLayout::U64);
+        let mapping = RecordingMapping {
+            expected_kind: IdentifierMappingKind::Aggregator,
+            expected_layout: MoveTypeLayout::U64,
+            returned_id: DelayedFieldID::new_with_width(42, 8),
+            seen_values: RefCell::new(Vec::new()),
+        };
+
+        let base = 123u64;
+        let max = 999u64;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&base.to_le_bytes());
+        bytes.extend_from_slice(&max.to_le_bytes());
+
+        let value =
+            deserialize_and_replace_values_with_ids::<DelayedFieldID>(&bytes, &layout, &mapping)
+                .expect("replace should succeed");
+        let serialized = serialize_and_allow_delayed_values(&value, &layout)
+            .unwrap()
+            .expect("serialize should succeed");
+
+        assert_eq!(mapping.seen_values.borrow().as_slice(), &[base as u128]);
+        assert_eq!(
+            &serialized[..8],
+            &mapping.returned_id.as_u64().to_le_bytes()
+        );
+        assert_eq!(&serialized[8..], &max.to_le_bytes());
+    }
+
+    #[test]
+    fn replace_values_with_ids_nested_native_u128() {
+        let layout = nested_layout(IdentifierMappingKind::Snapshot, MoveTypeLayout::U128);
+        let mapping = RecordingMapping {
+            expected_kind: IdentifierMappingKind::Snapshot,
+            expected_layout: MoveTypeLayout::U128,
+            returned_id: DelayedFieldID::new_with_width(77, 16),
+            seen_values: RefCell::new(Vec::new()),
+        };
+
+        let base = 123456u128;
+        let max = 789012u128;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&base.to_le_bytes());
+        bytes.extend_from_slice(&max.to_le_bytes());
+
+        let value =
+            deserialize_and_replace_values_with_ids::<DelayedFieldID>(&bytes, &layout, &mapping)
+                .expect("replace should succeed");
+        let serialized = serialize_and_allow_delayed_values(&value, &layout)
+            .unwrap()
+            .expect("serialize should succeed");
+
+        assert_eq!(mapping.seen_values.borrow().as_slice(), &[base]);
+        assert_eq!(
+            &serialized[..16],
+            &(mapping.returned_id.as_u64() as u128).to_le_bytes()
+        );
+        assert_eq!(&serialized[16..], &max.to_le_bytes());
+    }
 }

--- a/language/move-vm/types/src/values/value_tests.rs
+++ b/language/move-vm/types/src/values/value_tests.rs
@@ -235,7 +235,17 @@ mod native_values {
     use crate::delayed_values::delayed_field_id::{
         DelayedFieldID, ExtractUniqueIndex, ExtractWidth,
     };
+    use crate::value_serde::{
+        deserialize_and_replace_values_with_ids, serialize_and_allow_delayed_values,
+        ValueToIdentifierMapping,
+    };
     use claims::{assert_err, assert_ok};
+    use move_core_types::{
+        identifier::Identifier,
+        language_storage::StructTag,
+        value::{IdentifierMappingKind, MoveFieldLayout, MoveStructLayout, MoveTypeLayout},
+    };
+    use std::cell::RefCell;
 
     #[test]
     fn test_native_value_equality() {
@@ -291,5 +301,133 @@ mod native_values {
         let expected_id = assert_ok!(v.value_as::<DelayedFieldID>());
         assert_eq!(expected_id.extract_unique_index(), 0);
         assert_eq!(expected_id.extract_width(), 8);
+    }
+
+    fn id(name: &str) -> Identifier {
+        Identifier::new(name).unwrap()
+    }
+
+    fn nested_with_fields_layout(kind: IdentifierMappingKind) -> MoveTypeLayout {
+        MoveTypeLayout::Struct(MoveStructLayout::WithFields(vec![MoveFieldLayout::new(
+            id("outer"),
+            MoveTypeLayout::Struct(MoveStructLayout::WithFields(vec![
+                MoveFieldLayout::new(
+                    id("native"),
+                    MoveTypeLayout::Native(kind, Box::new(MoveTypeLayout::U64)),
+                ),
+                MoveFieldLayout::new(id("tail"), MoveTypeLayout::U64),
+            ])),
+        )]))
+    }
+
+    fn nested_with_types_layout(kind: IdentifierMappingKind) -> MoveTypeLayout {
+        let outer_tag = StructTag {
+            address: AccountAddress::ONE,
+            module: id("M"),
+            name: id("Outer"),
+            type_args: vec![],
+        };
+        let inner_tag = StructTag {
+            address: AccountAddress::ONE,
+            module: id("M"),
+            name: id("Inner"),
+            type_args: vec![],
+        };
+        MoveTypeLayout::Struct(MoveStructLayout::WithTypes {
+            type_: outer_tag,
+            fields: vec![MoveFieldLayout::new(
+                id("outer"),
+                MoveTypeLayout::Struct(MoveStructLayout::WithTypes {
+                    type_: inner_tag,
+                    fields: vec![
+                        MoveFieldLayout::new(
+                            id("native"),
+                            MoveTypeLayout::Native(kind, Box::new(MoveTypeLayout::U64)),
+                        ),
+                        MoveFieldLayout::new(id("tail"), MoveTypeLayout::U64),
+                    ],
+                }),
+            )],
+        })
+    }
+
+    struct Mapping {
+        id: DelayedFieldID,
+        seen: RefCell<Option<u64>>,
+    }
+
+    impl ValueToIdentifierMapping for Mapping {
+        type Identifier = DelayedFieldID;
+
+        fn value_to_identifier(
+            &self,
+            kind: &IdentifierMappingKind,
+            layout: &MoveTypeLayout,
+            value: Value,
+        ) -> PartialVMResult<Self::Identifier> {
+            assert_eq!(layout, &MoveTypeLayout::U64);
+            assert!(matches!(
+                kind,
+                IdentifierMappingKind::Aggregator | IdentifierMappingKind::Snapshot
+            ));
+            *self.seen.borrow_mut() = Some(value.value_as::<u64>()?);
+            Ok(self.id)
+        }
+
+        fn identifier_to_value(
+            &self,
+            _layout: &MoveTypeLayout,
+            _identifier: Self::Identifier,
+        ) -> PartialVMResult<Value> {
+            unreachable!("tests only need value_to_identifier path")
+        }
+    }
+
+    #[test]
+    fn test_exchange_nested_native_u64_with_with_fields_layout() {
+        let layout = nested_with_fields_layout(IdentifierMappingKind::Aggregator);
+        let delayed_id = DelayedFieldID::new_with_width(42, 8);
+        let mapping = Mapping {
+            id: delayed_id,
+            seen: RefCell::new(None),
+        };
+
+        let mut input = Vec::new();
+        input.extend_from_slice(&123u64.to_le_bytes());
+        input.extend_from_slice(&456u64.to_le_bytes());
+
+        let exchanged = deserialize_and_replace_values_with_ids(&input, &layout, &mapping)
+            .expect("exchange should succeed for WithFields nested native layout");
+        let output = serialize_and_allow_delayed_values(&exchanged, &layout)
+            .expect("serialization should succeed")
+            .expect("serialized bytes should exist");
+
+        assert_eq!(&output[0..8], &delayed_id.as_u64().to_le_bytes());
+        assert_eq!(&output[8..16], &456u64.to_le_bytes());
+        assert_eq!(*mapping.seen.borrow(), Some(123));
+    }
+
+    #[test]
+    fn test_exchange_nested_native_u64_with_with_types_layout() {
+        let layout = nested_with_types_layout(IdentifierMappingKind::Snapshot);
+        let delayed_id = DelayedFieldID::new_with_width(7, 8);
+        let mapping = Mapping {
+            id: delayed_id,
+            seen: RefCell::new(None),
+        };
+
+        let mut input = Vec::new();
+        input.extend_from_slice(&11u64.to_le_bytes());
+        input.extend_from_slice(&22u64.to_le_bytes());
+
+        let exchanged = deserialize_and_replace_values_with_ids(&input, &layout, &mapping)
+            .expect("exchange should succeed for WithTypes nested native layout");
+        let output = serialize_and_allow_delayed_values(&exchanged, &layout)
+            .expect("serialization should succeed")
+            .expect("serialized bytes should exist");
+
+        assert_eq!(&output[0..8], &delayed_id.as_u64().to_le_bytes());
+        assert_eq!(&output[8..16], &22u64.to_le_bytes());
+        assert_eq!(*mapping.seen.borrow(), Some(11));
     }
 }

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -3293,18 +3293,18 @@ impl<'c, 'l, 'v, C: CustomSerializer> serde::Serialize
 {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let values = &self.value;
-        let fields = self.layout.fields();
-        if fields.len() != values.len() {
+        let field_layouts = struct_field_layout_refs(self.layout);
+        if field_layouts.len() != values.len() {
             return Err(invariant_violation::<S>(format!(
                 "cannot serialize struct value {:?} as {:?} -- number of fields mismatch",
                 self.value, self.layout
             )));
         }
         let mut t = serializer.serialize_tuple(values.len())?;
-        for (field_layout, value) in fields.iter().zip(values.iter()) {
+        for (field_layout, value) in field_layouts.iter().zip(values.iter()) {
             t.serialize_element(&SerializationReadyValue {
                 custom_serializer: self.custom_serializer,
-                layout: field_layout,
+                layout: *field_layout,
                 value,
             })?;
         }
@@ -3409,7 +3409,7 @@ impl<'d, C: CustomDeserializer> serde::de::DeserializeSeed<'d>
         self,
         deserializer: D,
     ) -> Result<Self::Value, D::Error> {
-        let field_layouts = self.layout.fields();
+        let field_layouts = struct_field_layout_refs(self.layout);
         let fields = deserializer.deserialize_tuple(
             field_layouts.len(),
             StructFieldVisitor(self.custom_deserializer, field_layouts),
@@ -3442,7 +3442,7 @@ impl<'d, 'c, 'l, C: CustomDeserializer> serde::de::Visitor<'d> for VectorElement
     }
 }
 
-struct StructFieldVisitor<'c, 'l, C>(Option<&'c C>, &'l [MoveTypeLayout]);
+struct StructFieldVisitor<'c, 'l, C>(Option<&'c C>, Vec<&'l MoveTypeLayout>);
 
 impl<'d, 'c, 'l, C: CustomDeserializer> serde::de::Visitor<'d> for StructFieldVisitor<'c, 'l, C> {
     type Value = Vec<Value>;
@@ -3459,7 +3459,7 @@ impl<'d, 'c, 'l, C: CustomDeserializer> serde::de::Visitor<'d> for StructFieldVi
         for (i, field_layout) in self.1.iter().enumerate() {
             if let Some(elem) = seq.next_element_seed(DeserializationSeed {
                 custom_deserializer: self.0,
-                layout: field_layout,
+                layout: *field_layout,
             })? {
                 val.push(elem)
             } else {
@@ -3467,6 +3467,16 @@ impl<'d, 'c, 'l, C: CustomDeserializer> serde::de::Visitor<'d> for StructFieldVi
             }
         }
         Ok(val)
+    }
+}
+
+fn struct_field_layout_refs(layout: &MoveStructLayout) -> Vec<&MoveTypeLayout> {
+    match layout {
+        MoveStructLayout::Runtime(fields) => fields.iter().collect(),
+        MoveStructLayout::WithFields(fields) => fields.iter().map(|f| &f.layout).collect(),
+        MoveStructLayout::WithTypes { fields, .. } => {
+            fields.iter().map(|f| &f.layout).collect()
+        }
     }
 }
 

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -3144,6 +3144,8 @@ impl Value {
             custom_serializer: None::<&RelaxedCustomSerDe>,
             layout,
             value: &self.0,
+            max_value_nest_depth: None,
+            depth: 1,
         })
         .ok()
     }
@@ -3163,6 +3165,8 @@ impl Struct {
             custom_serializer: None::<&RelaxedCustomSerDe>,
             layout,
             value: &self.fields,
+            max_value_nest_depth: None,
+            depth: 1,
         })
         .ok()
     }
@@ -3177,6 +3181,10 @@ pub(crate) struct SerializationReadyValue<'c, 'l, 'v, L, V, C> {
     pub(crate) layout: &'l L,
     // Value to serialize.
     pub(crate) value: &'v V,
+    // Maximum allowed depth of the value graph.
+    pub(crate) max_value_nest_depth: Option<u64>,
+    // Current depth for this node.
+    pub(crate) depth: u64,
 }
 
 fn invariant_violation<S: serde::Serializer>(message: String) -> S::Error {
@@ -3185,11 +3193,19 @@ fn invariant_violation<S: serde::Serializer>(message: String) -> S::Error {
     )
 }
 
+fn check_depth(depth: u64, max_depth: Option<u64>) -> PartialVMResult<()> {
+    if max_depth.is_some_and(|limit| depth > limit) {
+        return Err(PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED));
+    }
+    Ok(())
+}
+
 impl<'c, 'l, 'v, C: CustomSerializer> serde::Serialize
     for SerializationReadyValue<'c, 'l, 'v, MoveTypeLayout, ValueImpl, C>
 {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use MoveTypeLayout as L;
+        check_depth(self.depth, self.max_value_nest_depth).map_err(S::Error::custom)?;
 
         match (self.layout, self.value) {
             // Primitive types.
@@ -3208,6 +3224,8 @@ impl<'c, 'l, 'v, C: CustomSerializer> serde::Serialize
                     custom_serializer: self.custom_serializer,
                     layout: struct_layout,
                     value: &*r.borrow(),
+                    max_value_nest_depth: self.max_value_nest_depth,
+                    depth: self.depth,
                 })
                 .serialize(serializer)
             }
@@ -3232,6 +3250,8 @@ impl<'c, 'l, 'v, C: CustomSerializer> serde::Serialize
                                 custom_serializer: self.custom_serializer,
                                 layout,
                                 value,
+                                max_value_nest_depth: self.max_value_nest_depth,
+                                depth: self.depth + 1,
                             })?;
                         }
                         t.end()
@@ -3256,6 +3276,8 @@ impl<'c, 'l, 'v, C: CustomSerializer> serde::Serialize
                     custom_serializer: self.custom_serializer,
                     layout: &L::Address,
                     value: &v[0],
+                    max_value_nest_depth: self.max_value_nest_depth,
+                    depth: self.depth,
                 })
                 .serialize(serializer)
             }
@@ -3306,6 +3328,8 @@ impl<'c, 'l, 'v, C: CustomSerializer> serde::Serialize
                 custom_serializer: self.custom_serializer,
                 layout: *field_layout,
                 value,
+                max_value_nest_depth: self.max_value_nest_depth,
+                depth: self.depth + 1,
             })?;
         }
         t.end()
@@ -3474,9 +3498,7 @@ fn struct_field_layout_refs(layout: &MoveStructLayout) -> Vec<&MoveTypeLayout> {
     match layout {
         MoveStructLayout::Runtime(fields) => fields.iter().collect(),
         MoveStructLayout::WithFields(fields) => fields.iter().map(|f| &f.layout).collect(),
-        MoveStructLayout::WithTypes { fields, .. } => {
-            fields.iter().map(|f| &f.layout).collect()
-        }
+        MoveStructLayout::WithTypes { fields, .. } => fields.iter().map(|f| &f.layout).collect(),
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Move Language.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/move-language/move/blob/main/CONTRIBUTING.md#developer-workflow)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
